### PR TITLE
Add explicit dependency on omniauth-oauth2

### DIFF
--- a/omniauth-phabricator.gemspec
+++ b/omniauth-phabricator.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.3"
+
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
The gem has a dependency on `omniauth-oauth2`, make that explicit in the gemspec.
